### PR TITLE
Added "Mark all as read" roster context option.

### DIFF
--- a/res/menu/roster_item_contextmenu.xml
+++ b/res/menu/roster_item_contextmenu.xml
@@ -5,6 +5,11 @@
 			android:title="@string/roster_contextmenu_contact_open_chat">
 		</item>
 
+		<item android:id="@+id/roster_contextmenu_contact_mark_all_as_read" android:visible="true"
+			android:enabled="true" android:orderInCategory="1"
+			android:title="@string/roster_contextmenu_contact_mark_all_as_read">
+		</item>
+
 		<item android:id="@+id/roster_contextmenu_contact_rename" android:visible="true"
 			android:enabled="true" android:orderInCategory="3"
 			android:title="@string/roster_contextmenu_contact_rename">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -112,6 +112,7 @@
 	<!-- Roster CONTEXTMENU -->
 	<string name="roster_contextmenu_title">Options for %s</string>
 	<string name="roster_contextmenu_group_rename">Rename group</string>
+	<string name="roster_contextmenu_contact_mark_all_as_read">Mark all messages as read</string>
 	<string name="roster_contextmenu_contact_delete">Delete Contact</string>
 	<string name="roster_contextmenu_contact_delmsg">Delete Chat History</string>
 	<string name="roster_contextmenu_contact_open_chat">Open Chat</string>

--- a/src/org/yaxim/androidclient/MainWindow.java
+++ b/src/org/yaxim/androidclient/MainWindow.java
@@ -21,6 +21,7 @@ import org.yaxim.androidclient.util.StatusMode;
 
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
+import android.content.ContentValues;
 import android.content.Context;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -300,6 +301,17 @@ public class MainWindow extends SherlockExpandableListActivity {
 		menu.setHeaderTitle(getString(R.string.roster_contextmenu_title, menuName));
 	}
 
+	void doMarkAllAsRead(final String JID) {
+		ContentValues values = new ContentValues();
+		values.put(ChatConstants.DELIVERY_STATUS, ChatConstants.DS_SENT_OR_READ);
+
+		getContentResolver().update(ChatProvider.CONTENT_URI, values,
+				ChatProvider.ChatConstants.JID + " = ? AND "
+						+ ChatConstants.DIRECTION + " = " + ChatConstants.INCOMING + " AND "
+						+ ChatConstants.DELIVERY_STATUS + " = " + ChatConstants.DS_NEW,
+				new String[]{JID});
+	}
+
 	void removeChatHistory(final String JID) {
 		getContentResolver().delete(ChatProvider.CONTENT_URI,
 				ChatProvider.ChatConstants.JID + " = ?", new String[] { JID });
@@ -453,6 +465,10 @@ public class MainWindow extends SherlockExpandableListActivity {
 			switch (itemID) {
 			case R.id.roster_contextmenu_contact_open_chat:
 				startChatActivity(userJid, userName, null);
+				return true;
+
+			case R.id.roster_contextmenu_contact_mark_all_as_read:
+				doMarkAllAsRead(userJid);
 				return true;
 
 			case R.id.roster_contextmenu_contact_delmsg:


### PR DESCRIPTION
Added "Mark all as read" roster context option. Clicking it will set delivery status to read where messages are incoming and new.
This could close issue #104.
