### PR TITLE
Keep your app name

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="app_name">yaxim</string>
-	<string name="app_name_bruno">Bruno</string>
+	<string name="app_name" translatable="false">yaxim</string>
+	<string name="app_name_bruno" translatable="false">Bruno</string>
 
 	<!-- Connection state -->
 	<string name="conn_title">yaxim: %s</string>


### PR DESCRIPTION
...if translated it makes it harder to find and reference